### PR TITLE
Fixes #129 Questionnaire copyright conversion

### DIFF
--- a/src/fhir/sdc-export-common.js
+++ b/src/fhir/sdc-export-common.js
@@ -26,7 +26,7 @@ function addCommonSDCExportFns(ns) {
         target = {};
         this._processRepeatingItemValues(source);
         this._setResponseFormLevelFields(target, source, noExtensions);
-  
+
         if (source.items && Array.isArray(source.items)) {
           var tmp = this._processResponseItem(source, true);
           if(tmp && tmp.item && tmp.item.length) {
@@ -380,6 +380,11 @@ function addCommonSDCExportFns(ns) {
     // resourceType
     target.resourceType = "Questionnaire";
     target.status = target.status ? target.status : "draft";
+
+    // handle lforms copyright
+    if (source.copyrightNotice) {
+      target.copyright = source.copyrightNotice;
+    }
 
     // meta
     this._handleMeta(target);

--- a/src/fhir/sdc-import-common.js
+++ b/src/fhir/sdc-import-common.js
@@ -164,7 +164,6 @@ function addCommonSDCImportFns(ns) {
     'useContext',
     'jurisdiction',
     'purpose',
-    'copyright',
     'approvalDate',
     'reviewDate',
     'effectivePeriod',
@@ -231,6 +230,12 @@ function addCommonSDCImportFns(ns) {
       // Rename questionnaire code to codeList
       lfData.codeList = questionnaire.code;
     }
+
+    // copy over the copyright
+    if (questionnaire.copyright) {
+      lfData.copyrightNotice = questionnaire.copyright;
+    }
+
     var codeAndSystemObj = self._getCode(questionnaire);
     if(codeAndSystemObj) {
       lfData.code = codeAndSystemObj.code;
@@ -1442,7 +1447,7 @@ function addCommonSDCImportFns(ns) {
    * that have an answer list.
    * @param {*} answer an answer of an item in QuestionnaireResponse
    * @param {*} lfItem an item in lforms
-   * @returns 
+   * @returns
    */
   self._processOtherAnswerOptionValueInQR = function(answer, item) {
 
@@ -1472,13 +1477,13 @@ function addCommonSDCImportFns(ns) {
    * that have an answer list, to lforms values
    * @param {*} qrItemValue a value of item in QuestionnaireResponse
    * @param {*} lfItem an item in lforms
-   * @returns 
+   * @returns
    */
   self._convertOtherAnswerOptionValueInQR = function(qrItemValue, lfItem) {
     let retValue;
     let dataType = lfItem.dataType;
 
-    if (lfItem.answers && (dataType === "ST" || dataType === "INT" || 
+    if (lfItem.answers && (dataType === "ST" || dataType === "INT" ||
         dataType === "DT" || dataType === "TM")) {
       let answerText;
       switch (dataType) {
@@ -1495,7 +1500,7 @@ function addCommonSDCImportFns(ns) {
           answerText = qrItemValue.valueTime;
           break;
       }
-      if (answerText) 
+      if (answerText)
         retValue = { text: answerText };
     }
 

--- a/test/data/lforms/FHTData.json
+++ b/test/data/lforms/FHTData.json
@@ -3,6 +3,7 @@
   "code": "54127-6N",
   "name": "USSG-FHT, (with mock-up items for skip logic demo)",
   "template": "table",
+  "copyrightNotice": "A Copyright notice of the form",
   "items": [
     {
       "questionCode": "54126-8",

--- a/test/karma/fhir-sdc.spec.js
+++ b/test/karma/fhir-sdc.spec.js
@@ -1140,6 +1140,7 @@ for (var i=0, len=fhirVersions.length; i<len; ++i) {
               assert.equal(convertedLfData.name, 'USSG-FHT, (with mock-up items for skip logic demo)');
               assert.equal(convertedLfData.code, '54127-6N');
               assert.equal(convertedLfData.codeSystem, 'LOINC');
+              assert.equal(convertedLfData.copyrightNotice, 'A Copyright notice of the form', "LHCFormData.copyrightNotice should be copied from Questionnaire.copyright property");
               assert.equal(convertedLfData.codeList.length, 1);
               assert.equal(convertedLfData.codeList[0].code, '54127-6N');
               assert.equal(convertedLfData.codeList[0].system, 'http://loinc.org');
@@ -1499,6 +1500,15 @@ for (var i=0, len=fhirVersions.length; i<len; ++i) {
             var out = fhir.SDC._processItem(item, {});
             assert.equal(out.prefix, "A:");
             assert.equal(out.text, "fill in weight");
+          });
+
+          it('should convert copyrightNotice to copyright', function(done) {
+            $.get('/base/test/data/lforms/FHTData.json', function(FHTData) {
+              var fhirQ = fhir.SDC.convertLFormsToQuestionnaire(new LForms.LFormsData(LForms.Util.deepCopy(FHTData)));
+              assert.equal(fhirQ.copyright, FHTData.copyrightNotice, "copyright should be populated with lForms copyrightText value");
+              assert.equal(fhirQ.copryrightNotice, undefined, "copyrightText property should not exist on questionnaire");
+              done();
+            });
           });
 
           if(fhirVersion === 'STU3') {


### PR DESCRIPTION
Fixes #129 

Changed export process to populate Questionnaire.copyright property when converting from LHCFormData.

Changed import process to populate the LHCFormData.copyrightNotice property when converting from Questionnaire.

Added test cases to verify both export and import properly handle the copyright conversion.