### PR TITLE
Fix score calculation different extensions

### DIFF
--- a/src/fhir/R4R5-common/sdc-export.js
+++ b/src/fhir/R4R5-common/sdc-export.js
@@ -377,7 +377,7 @@ var self = {
 
       if (answer.score !== null && answer.score !== undefined) {
         ext.push({
-          url: this.fhirExtUrlOptionScore,
+          url: answer._scoreExtUrl || this.fhirExtUrlOptionScore,
           valueDecimal: answer.score,
         });
       }

--- a/src/fhir/R4R5-common/sdc-import.js
+++ b/src/fhir/R4R5-common/sdc-import.js
@@ -187,6 +187,7 @@ function addSDCImportFns(ns) {
           score = !score ? LForms.Util.findObjectInArray(option.extension, 'url', self.argonautExtUrlExtensionScore) : score;
           if(score) {
             answer.score = parseFloat(score.valueDecimal);
+            answer._scoreExtUrl = score.url;
           }
 
         }

--- a/src/fhir/STU3/sdc-export.js
+++ b/src/fhir/STU3/sdc-export.js
@@ -351,7 +351,7 @@ var self = {
 
       if (answer.score !== null && answer.score !== undefined) {
         ext.push({
-          "url" : this.fhirExtUrlOptionScore,
+          "url" : answer._scoreExtUrl || this.fhirExtUrlOptionScore,
           "valueDecimal" : answer.score
         });
       }

--- a/src/fhir/STU3/sdc-import.js
+++ b/src/fhir/STU3/sdc-import.js
@@ -212,6 +212,7 @@ function addSDCImportFns(ns) {
           score = !score ? LForms.Util.findObjectInArray(option.extension, 'url', self.argonautExtUrlExtensionScore) : score;
           if(score) {
             answer.score = parseFloat(score.valueDecimal);
+            answer._scoreExtUrl = score.url;
           }
 
         }

--- a/test/data/R4/apgar-with-itemWeight-variable.json
+++ b/test/data/R4/apgar-with-itemWeight-variable.json
@@ -1,0 +1,294 @@
+{
+  "resourceType": "Questionnaire",
+  "title": "1-Minute Apgar Score",
+  "status": "active",
+  "item": [
+    {
+      "linkId": "32406-1",
+      "text": "1-Min-Apgar Hautfarbe",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6722-8",
+            "display": "Blaugrau oder blass"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 0
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6723-6",
+            "display": "Gute Körperfarbe mit blauen Händen oder Füßen"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 1
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6724-4",
+            "display": "Gute Farbe am gesamten Körper"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "linkId": "32407-9",
+      "text": "1-Min-Apgar Herzfrequenz",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6716-0",
+            "display": "Keine Herzfrequenz"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 0
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6717-8",
+            "display": "Unter 100 Schläge pro Minute"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 1
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6718-6",
+            "display": "Mindestens 100 Schläge pro Minute"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "linkId": "32409-5",
+      "text": "1-Min-Apgar Reflexreaktion",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6719-4",
+            "display": "Keine Reaktion"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 0
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6720-2",
+            "display": "Grimasse"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 1
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6721-0",
+            "display": "Grimasse und Zurückziehen"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "linkId": "32408-7",
+      "text": "1-Min-Apgar Muskeltonus",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6713-7",
+            "display": "Schlaff"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 0
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6714-5",
+            "display": "Etwas Beugung"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 1
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6715-2",
+            "display": "Aktive Bewegung"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "linkId": "32410-3",
+      "text": "1-Min-Apgar Atemanstrengung",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6725-1",
+            "display": "Keine Atmung"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 0
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6726-9",
+            "display": "Schwacher Schrei"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 1
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6727-7",
+            "display": "Guter, kräftiger Schrei"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/itemWeight",
+              "valueDecimal": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "linkId": "9272-6",
+      "text": "1-Min-Apgar Gesamtpunktzahl",
+      "type": "decimal",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/variable",
+          "valueExpression": {
+            "name": "a",
+            "language": "text/fhirpath",
+            "expression": "%questionnaire.item.where(linkId = '32406-1').answerOption.where(valueCoding.code=%resource.item.where(linkId = '32406-1').answer.valueCoding.code).extension.where(url='http://hl7.org/fhir/StructureDefinition/itemWeight').valueDecimal"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/variable",
+          "valueExpression": {
+            "name": "b",
+            "language": "text/fhirpath",
+            "expression": "%questionnaire.item.where(linkId = '32407-9').answerOption.where(valueCoding.code=%resource.item.where(linkId = '32407-9').answer.valueCoding.code).extension.where(url='http://hl7.org/fhir/StructureDefinition/itemWeight').valueDecimal"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/variable",
+          "valueExpression": {
+            "name": "c",
+            "language": "text/fhirpath",
+            "expression": "%questionnaire.item.where(linkId = '32409-5').answerOption.where(valueCoding.code=%resource.item.where(linkId = '32409-5').answer.valueCoding.code).extension.where(url='http://hl7.org/fhir/StructureDefinition/itemWeight').valueDecimal"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/variable",
+          "valueExpression": {
+            "name": "d",
+            "language": "text/fhirpath",
+            "expression": "%questionnaire.item.where(linkId = '32408-7').answerOption.where(valueCoding.code=%resource.item.where(linkId = '32408-7').answer.valueCoding.code).extension.where(url='http://hl7.org/fhir/StructureDefinition/itemWeight').valueDecimal"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/variable",
+          "valueExpression": {
+            "name": "e",
+            "language": "text/fhirpath",
+            "expression": "%questionnaire.item.where(linkId = '32410-3').answerOption.where(valueCoding.code=%resource.item.where(linkId = '32410-3').answer.valueCoding.code).extension.where(url='http://hl7.org/fhir/StructureDefinition/itemWeight').valueDecimal"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "description": "Total score (only when all 5 answered)",
+            "language": "text/fhirpath",
+            "expression": "iif(%a.exists() and %b.exists() and %c.exists() and %d.exists() and %e.exists(), %a + %b + %c + %d + %e, {})"
+          }
+        }
+      ]
+    }
+  ]
+}
+

--- a/test/karma/expression.spec.js
+++ b/test/karma/expression.spec.js
@@ -448,7 +448,7 @@ describe('ExpressionProcessor', function () {
     })
     it('should be supported', function(done) {
       mockFetchResults([[
-        /https:\/\/clinicaltables\.nlm\.nih\.gov\/fhir\/R4\/CodeSystem\/\$lookup\?system=https:\/\/clinicaltables.nlm\.nih\.gov\/fhir\/CodeSystem\/rxterms&code=AR&property=STRENGTHS_AND_FORMS&_format=json/,
+        /https:\/\/clinicaltables\.nlm\.nih\.gov\/fhir\/R4\/CodeSystem\/\$lookup\?system=https:\/\/clinicaltables\.nlm\.nih\.gov\/fhir\/CodeSystem\/rxterms&code=AR&property=STRENGTHS_AND_FORMS&_format=json/,
         {
           "resourceType": "Parameters",
           "parameter": [

--- a/test/karma/expression.spec.js
+++ b/test/karma/expression.spec.js
@@ -448,7 +448,7 @@ describe('ExpressionProcessor', function () {
     })
     it('should be supported', function(done) {
       mockFetchResults([[
-        /https:\/\/clinicaltables\.nlm\.nih\.gov\/fhir\/R4\/CodeSystem\/\$lookup\?system=https:\/\/clinicaltables\.nlm\.nih\.gov\/fhir\/CodeSystem\/rxterms&code=AR&property=STRENGTHS_AND_FORMS&_format=json/,
+        /https:\/\/clinicaltables\.nlm\.nih\.gov\/fhir\/R4\/CodeSystem\/\$lookup\?system=https:\/\/clinicaltables.nlm\.nih\.gov\/fhir\/CodeSystem\/rxterms&code=AR&property=STRENGTHS_AND_FORMS&_format=json/,
         {
           "resourceType": "Parameters",
           "parameter": [
@@ -700,6 +700,66 @@ describe('ExpressionProcessor', function () {
             assert.equal(testLFData.itemList[9].value, undefined);
             return testLFData._expressionProcessor.runCalculations(true).then(()=>{
               assert.equal(testLFData.itemList[9].value, 9);
+            });
+          });
+        });
+
+        describe('Apgar with itemWeight variable referencing itemWeight URL in %questionnaire', function () {
+          // Regression test: when a Questionnaire uses itemWeight extensions on answerOptions
+          // and variable expressions reference them via %questionnaire...extension.where(url='...itemWeight'),
+          // the re-exported %questionnaire must preserve the original itemWeight URL so the
+          // calculation works correctly after import.
+          let apgarTestQ;
+          before(function(done) {
+            LForms.jQuery.get('test/data/R4/apgar-with-itemWeight-variable.json', function (parsedJson) {
+              apgarTestQ = parsedJson;
+              done();
+            }).fail(function(e) {
+              console.error(e);
+              done(e);
+            });
+          });
+
+          it('should calculate the total score using itemWeight variable expressions', function() {
+            let lformsDef = LForms.Util.convertFHIRQuestionnaireToLForms(apgarTestQ, modelName);
+            const testLFData = new LForms.LFormsData(lformsDef);
+            // Set score=2 (highest) for all 5 Apgar items → expected total = 10
+            const apgarLinkIds = ['32406-1', '32407-9', '32409-5', '32408-7', '32410-3'];
+            const scoreAnswers = {
+              '32406-1': 'LA6724-4',
+              '32407-9': 'LA6718-6',
+              '32409-5': 'LA6721-0',
+              '32408-7': 'LA6715-2',
+              '32410-3': 'LA6727-7'
+            };
+            testLFData.itemList.forEach(item => {
+              if (apgarLinkIds.includes(item.linkId)) {
+                item.value = {
+                  code: scoreAnswers[item.linkId],
+                  system: 'http://loinc.org'
+                };
+              }
+            });
+            const totalScoreItem = testLFData.itemList.find(item => item.linkId === '9272-6');
+            assert.ok(totalScoreItem, 'Total score item should exist');
+            assert.equal(totalScoreItem.value, undefined);
+            return testLFData._expressionProcessor.runCalculations(true).then(() => {
+              // 5 items × score 2 = 10
+              assert.equal(totalScoreItem.value, 10);
+            });
+          });
+
+          it('should not calculate total score when not all items are answered', function() {
+            let lformsDef = LForms.Util.convertFHIRQuestionnaireToLForms(apgarTestQ, modelName);
+            const testLFData = new LForms.LFormsData(lformsDef);
+            // Only answer 3 of 5 items — total should be empty (iif guard)
+            testLFData.itemList.find(i => i.linkId === '32406-1').value = {code: 'LA6723-6', system: 'http://loinc.org'}; // score 1
+            testLFData.itemList.find(i => i.linkId === '32407-9').value = {code: 'LA6717-8', system: 'http://loinc.org'}; // score 1
+            testLFData.itemList.find(i => i.linkId === '32409-5').value = {code: 'LA6720-2', system: 'http://loinc.org'}; // score 1
+            const totalScoreItem = testLFData.itemList.find(item => item.linkId === '9272-6');
+            return testLFData._expressionProcessor.runCalculations(true).then(() => {
+              // Not all answered → iif returns {} → value should be undefined/empty
+              assert.ok(totalScoreItem.value === undefined || totalScoreItem.value === null || totalScoreItem.value === '');
             });
           });
         });

--- a/test/karma/fhir-answerOption.R5.spec.js
+++ b/test/karma/fhir-answerOption.R5.spec.js
@@ -1,5 +1,11 @@
 // Tests for FHIR SDC library
 
+const scoreExtUrlR5 = 'http://hl7.org/fhir/StructureDefinition/itemWeight';
+
+function withScoreExtUrlR5(answers) {
+  return answers.map(a => Object.assign({}, a, {_scoreExtUrl: scoreExtUrlR5}));
+}
+
 function testImportAnswerOption(params, answerConstraint) {
   let fhirVersion = "R5";
   let fhir = LForms.FHIR[fhirVersion];
@@ -18,6 +24,7 @@ function testImportAnswerOption(params, answerConstraint) {
       $.get(file, function (fhirQ) {
         try {
           let lfData = LForms.Util.convertFHIRQuestionnaireToLForms(fhirQ, fhirVersion);
+          let answersWithPrefixScoreAndUrl = withScoreExtUrlR5(params.answersWithPrefixScore);
 
           //answerOption - autocomplete
           assert.deepEqual(lfData.items[0].items[0].answers, params.answers)
@@ -34,17 +41,17 @@ function testImportAnswerOption(params, answerConstraint) {
           assert.deepEqual(lfData.items[1].items[1].displayControl, displayControlRadioCheckboxHorizontal)
           assert.deepEqual(lfData.items[1].items[1].answerCardinality, answerCardinalityRepeats)
           //answerOption - prefix- score
-          assert.deepEqual(lfData.items[2].items[0].answers, params.answersWithPrefixScore)
+          assert.deepEqual(lfData.items[2].items[0].answers, answersWithPrefixScoreAndUrl)
           assert.deepEqual(lfData.items[2].items[0].displayControl, displayControlCombo)
           assert.deepEqual(lfData.items[2].items[0].answerCardinality, answerCardinalityNonRepeats)
-          assert.deepEqual(lfData.items[2].items[1].answers, params.answersWithPrefixScore)
+          assert.deepEqual(lfData.items[2].items[1].answers, answersWithPrefixScoreAndUrl)
           assert.deepEqual(lfData.items[2].items[1].displayControl, displayControlCombo)
           assert.deepEqual(lfData.items[2].items[1].answerCardinality, answerCardinalityRepeats)
           //answerOption - radiocheckbox - prefix - score
-          assert.deepEqual(lfData.items[3].items[0].answers, params.answersWithPrefixScore)
+          assert.deepEqual(lfData.items[3].items[0].answers, answersWithPrefixScoreAndUrl)
           assert.deepEqual(lfData.items[3].items[0].displayControl, displayControlRadioCheckboxVertical)
           assert.deepEqual(lfData.items[3].items[0].answerCardinality, answerCardinalityNonRepeats)
-          assert.deepEqual(lfData.items[3].items[1].answers, params.answersWithPrefixScore)
+          assert.deepEqual(lfData.items[3].items[1].answers, answersWithPrefixScoreAndUrl)
           assert.deepEqual(lfData.items[3].items[1].displayControl, displayControlRadioCheckboxHorizontal)
           assert.deepEqual(lfData.items[3].items[1].answerCardinality, answerCardinalityRepeats)
           //answerOption - autocomplete - initial
@@ -301,7 +308,7 @@ describe('coding in R5 with answerConstraint to choice/open-choice in R4', funct
       let errMessage = "The type 'coding' with answerConstraint 'optionsOrType' in R5 cannot be converted to a valid type in R4 or STU3."
       assert.equal(e.message, errMessage);
     }
-     
+
     // R5 to STU3
     try {
       let lfData = LForms.Util.convertFHIRQuestionnaireToLForms(qR5b, 'R5');

--- a/test/karma/fhir-answerOption.spec.js
+++ b/test/karma/fhir-answerOption.spec.js
@@ -2,6 +2,18 @@
 //let fhirVers = Object.keys(LForms.Util.FHIRSupport);
 const fhirVers = ["R4", "STU3"];
 
+// Score extension URLs per FHIR version (must match fhirExtUrlOptionScoreLookup in sdc-import-common.js)
+const scoreExtUrlByVersion = {
+  'R4':   'http://hl7.org/fhir/StructureDefinition/ordinalValue',
+  'R4B':  'http://hl7.org/fhir/StructureDefinition/ordinalValue',
+  'STU3': 'http://hl7.org/fhir/StructureDefinition/questionnaire-ordinalValue',
+  'R5':   'http://hl7.org/fhir/StructureDefinition/itemWeight'
+};
+
+function withScoreExtUrl(answers, scoreExtUrl) {
+  return answers.map(a => Object.assign({}, a, {_scoreExtUrl: scoreExtUrl}));
+}
+
 function testImportAnswerOption(params) {
   for (var i=0, len=fhirVers.length; i<len; ++i) {
     (function (fhirVersion) {
@@ -20,6 +32,7 @@ function testImportAnswerOption(params) {
           LForms.jQuery.get(file, function (fhirQ) {
             try {
               let lfData = LForms.Util.convertFHIRQuestionnaireToLForms(fhirQ, fhirVersion);
+              let answersWithPrefixScoreAndUrl = withScoreExtUrl(params.answersWithPrefixScore, scoreExtUrlByVersion[fhirVersion]);
 
               //answerOption - autocomplete
               assert.deepEqual(lfData.items[0].items[0].answers, params.answers)
@@ -36,17 +49,17 @@ function testImportAnswerOption(params) {
               assert.deepEqual(lfData.items[1].items[1].displayControl, displayControlRadioCheckboxHorizontal)
               assert.deepEqual(lfData.items[1].items[1].answerCardinality, answerCardinalityRepeats)
               //answerOption - prefix- score
-              assert.deepEqual(lfData.items[2].items[0].answers, params.answersWithPrefixScore)
+              assert.deepEqual(lfData.items[2].items[0].answers, answersWithPrefixScoreAndUrl)
               assert.deepEqual(lfData.items[2].items[0].displayControl, displayControlCombo)
               assert.deepEqual(lfData.items[2].items[0].answerCardinality, answerCardinalityNonRepeats)
-              assert.deepEqual(lfData.items[2].items[1].answers, params.answersWithPrefixScore)
+              assert.deepEqual(lfData.items[2].items[1].answers, answersWithPrefixScoreAndUrl)
               assert.deepEqual(lfData.items[2].items[1].displayControl, displayControlCombo)
               assert.deepEqual(lfData.items[2].items[1].answerCardinality, answerCardinalityRepeats)
               //answerOption - radiocheckbox - prefix - score
-              assert.deepEqual(lfData.items[3].items[0].answers, params.answersWithPrefixScore)
+              assert.deepEqual(lfData.items[3].items[0].answers, answersWithPrefixScoreAndUrl)
               assert.deepEqual(lfData.items[3].items[0].displayControl, displayControlRadioCheckboxVertical)
               assert.deepEqual(lfData.items[3].items[0].answerCardinality, answerCardinalityNonRepeats)
-              assert.deepEqual(lfData.items[3].items[1].answers, params.answersWithPrefixScore)
+              assert.deepEqual(lfData.items[3].items[1].answers, answersWithPrefixScoreAndUrl)
               assert.deepEqual(lfData.items[3].items[1].displayControl, displayControlRadioCheckboxHorizontal)
               assert.deepEqual(lfData.items[3].items[1].answerCardinality, answerCardinalityRepeats)
               //answerOption - autocomplete - initial

--- a/test/karma/fhir-sdc.spec.js
+++ b/test/karma/fhir-sdc.spec.js
@@ -2053,9 +2053,9 @@ for (var i=0, len=fhirVersions.length; i<len; ++i) {
                   var convertedQ = LForms.Util.getFormFHIRData('Questionnaire', fhirVersion, lfData);
 
                   assert.equal(convertedQ.item[11].item[0].option.length, json.item[11].item[0].option.length);
-                  // The score is changed from argonaut extension to FHIR extension.
+                  // The score extension URL is preserved from the original input (argonaut URL).
                   assert.equal(convertedQ.item[11].item[0].option[0].extension[0].url,
-                      'http://hl7.org/fhir/StructureDefinition/questionnaire-ordinalValue');
+                      json.item[11].item[0].option[0].extension[0].url);
                   assert.equal(convertedQ.item[11].item[0].option[0].extension[0].valueDecimal,
                       json.item[11].item[0].option[0].extension[0].valueDecimal);
                 }).done(function () {


### PR DESCRIPTION
## Summary

Fixes score-calculation breakage when a Questionnaire uses non-default score extension URLs (e.g. `itemWeight` or Argonaut) and FHIRPath expressions explicitly reference `%questionnaire...extension.where(url='...')`.

## Root Cause

Import accepted multiple score extension URLs, but export always normalized to a version-specific default (`fhirExtUrlOptionScore`).

That changed extension URLs during `%questionnaire` rebuild (`convertLFormsToQuestionnaire()`), so expressions expecting the original URL no longer matched.

## Changes

### Import: preserve original score extension URL
- `src/fhir/R4R5-common/sdc-import.js`
- `src/fhir/STU3/sdc-import.js`

Added:
```js
answer._scoreExtUrl = score.url;
```

### Export: prefer preserved URL
- `src/fhir/R4R5-common/sdc-export.js`
- `src/fhir/STU3/sdc-export.js`

Changed:
```js
url: answer._scoreExtUrl || this.fhirExtUrlOptionScore
```

## Tests

### New regression fixture
- `test/data/R4/apgar-with-itemWeight-variable.json`

### New regression tests
- `test/karma/expression.spec.js`
- Verifies:
  - all 5 Apgar answers selected => total score `10`
  - partial answers => empty result (guarded `iif`)

### Updated expectations for preserved URL metadata
- `test/karma/fhir-answerOption.spec.js`
- `test/karma/fhir-answerOption.R5.spec.js`
- Include `_scoreExtUrl` in expected answers.

### Updated Argonaut roundtrip expectation
- `test/karma/fhir-sdc.spec.js`
- Expects original Argonaut score extension URL to be preserved instead of normalized.
