### PR TITLE
Fix skip-logic infinite loop when evaluating nested conditional items

### DIFF
--- a/src/lib/lforms/lhc-form-data.ts
+++ b/src/lib/lforms/lhc-form-data.ts
@@ -767,6 +767,11 @@ export default class LhcFormData {
   _updateItemSkipLogicStatus(item, disabled) {
     let changed = false;
     let isDisabled;
+    // Enforce ancestor visibility when this function is called on an item directly
+    // (e.g. from flat item iteration), not only when reached via parent recursion.
+    if (!disabled && item?._parentItem?._skipLogicStatus === CONSTANTS.SKIP_LOGIC.STATUS_DISABLED) {
+      disabled = true;
+    }
     // if one item is hidden all of its decedents should be hidden.
     // not necessary to check skip logic, assuming 'hide' has the priority over 'show'
     if (disabled) {

--- a/test/cypress/integration/enablewhen-not-equals-loop.cy.js
+++ b/test/cypress/integration/enablewhen-not-equals-loop.cy.js
@@ -1,0 +1,174 @@
+describe('enableWhen != minimal reproduction', () => {
+  it('checks if != on coded answer loops in init', () => {
+    cy.visit('/test/pages/addFormToPageTest.html');
+
+    cy.window().then((win) => {
+      function run(q) {
+        const proto = win.LForms.LFormsData.prototype;
+        const origSet = proto._setSkipLogicStatusValue;
+        const origUpd = proto._updateItemSkipLogicStatus;
+        let guard = 0;
+        let initError = null;
+
+        proto._setSkipLogicStatusValue = function(item, newStatus, noLog = false) {
+          return origSet.call(this, item, newStatus, noLog);
+        };
+
+        proto._updateItemSkipLogicStatus = function(item, disabled) {
+          guard++;
+          if (guard > 300000) {
+            throw new Error('guard-hit');
+          }
+          return origUpd.call(this, item, disabled);
+        };
+
+        try {
+          const lfDef = win.LForms.Util.convertFHIRQuestionnaireToLForms(q, 'R4');
+          new win.LForms.LFormsData(lfDef);
+        } catch (e) {
+          initError = e?.message || String(e);
+        } finally {
+          proto._setSkipLogicStatusValue = origSet;
+          proto._updateItemSkipLogicStatus = origUpd;
+        }
+        return { initError, guard };
+      }
+
+      const qAnswerOption = {
+        resourceType: 'Questionnaire',
+        status: 'draft',
+        item: [
+          {
+            linkId: 'q1',
+            text: 'Controller',
+            type: 'choice',
+            answerOption: [
+              { valueCoding: { code: 'A', display: 'A' } },
+              { valueCoding: { code: 'B', display: 'B' } }
+            ]
+          },
+          {
+            linkId: 'q2',
+            text: 'Dependent',
+            type: 'string',
+            enableBehavior: 'all',
+            enableWhen: [
+              {
+                question: 'q1',
+                operator: '!=',
+                answerCoding: { code: 'A' }
+              }
+            ]
+          }
+        ]
+      };
+
+      const qAnswerValueSet = {
+        resourceType: 'Questionnaire',
+        status: 'draft',
+        item: [
+          {
+            linkId: 'q1',
+            text: 'Controller VS',
+            type: 'choice',
+            answerValueSet: 'https://art-decor.org/fhir/ValueSet/2.16.840.1.113883.3.1937.777.18.11.12046',
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'autocomplete'
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            linkId: 'q2',
+            text: 'Dependent VS',
+            type: 'string',
+            enableBehavior: 'all',
+            enableWhen: [
+              {
+                question: 'q1',
+                operator: '!=',
+                answerCoding: { system: 'http://loinc.org', code: 'LA27259-3' }
+              }
+            ]
+          }
+        ]
+      };
+
+      const qNestedGroup = {
+        resourceType: 'Questionnaire',
+        status: 'draft',
+        item: [
+          {
+            linkId: 'p1',
+            text: 'Parent controller',
+            type: 'choice',
+            answerOption: [
+              { valueCoding: { code: 'YES', display: 'Yes' } },
+              { valueCoding: { code: 'NO', display: 'No' } }
+            ]
+          },
+          {
+            linkId: 'g1',
+            text: 'Conditional group',
+            type: 'group',
+            enableBehavior: 'all',
+            enableWhen: [
+              {
+                question: 'p1',
+                operator: '=',
+                answerCoding: { code: 'YES' }
+              }
+            ],
+            item: [
+              {
+                linkId: 'c1',
+                text: 'Inner controller',
+                type: 'choice',
+                answerOption: [
+                  { valueCoding: { code: 'A', display: 'A' } },
+                  { valueCoding: { code: 'B', display: 'B' } }
+                ]
+              },
+              {
+                linkId: 'd1',
+                text: 'Inner dependent',
+                type: 'string',
+                enableBehavior: 'all',
+                enableWhen: [
+                  {
+                    question: 'c1',
+                    operator: '!=',
+                    answerCoding: { code: 'A' }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+
+      win.__neqDiag = {
+        answerOption: run(qAnswerOption),
+        answerValueSet: run(qAnswerValueSet),
+        nestedGroup: run(qNestedGroup)
+      };
+    });
+
+    cy.window().then((win) => {
+      const d = win.__neqDiag;
+      cy.writeFile('enablewhen-not-equals-minimal.json', d);
+      expect(d).to.exist;
+      expect(d.answerOption.initError, JSON.stringify(d)).to.equal(null);
+      expect(d.answerValueSet.initError, JSON.stringify(d)).to.equal(null);
+      expect(d.nestedGroup.initError, JSON.stringify(d)).to.equal(null);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This change fixes a rendering freeze caused by an infinite skip-logic update loop in nested conditional structures.

The issue occurred when an item was evaluated directly from the flat iteration path, without consistently enforcing that a disabled parent must force descendants to remain disabled.

## Root Cause
In `_checkFormControls()`, skip logic is evaluated across `itemList` and also recursively.  
For nested conditional items, a child could be reconsidered as enabled during direct evaluation even though its parent was already disabled.

This created repeated status changes and a non-terminating `while (changed)` loop.

## Fix
File: `src/lib/lforms/lhc-form-data.ts`

In `_updateItemSkipLogicStatus(item, disabled)`:
- add a parent-disabled inheritance check even for direct calls:

```ts
if (!disabled && item?._parentItem?._skipLogicStatus === CONSTANTS.SKIP_LOGIC.STATUS_DISABLED) {
  disabled = true;
}
```

This guarantees parent visibility rules are always applied before local skip logic evaluation.

## Regression Test
File: `test/cypress/integration/enablewhen-not-equals-loop.cy.js`

Covers:
- flat `enableWhen !=` case (no loop),
- `answerValueSet` case (no loop),
- nested conditional-group + inner `!=` case (previously looped, now stable).

## Validation
Executed:
```bash
npx start-server-and-test "npm run start:fhir-dev" http://localhost:4201 \
  "npx start-server-and-test \"npm run start:lforms-dev\" http://localhost:4200 \
  \"npx cypress run --spec test/cypress/integration/enablewhen-not-equals-loop.cy.js --browser chrome\""
```

Result:
- 1 spec passed
- no initialization loop
- test-only loop detector (`guard-hit`) was not triggered

## Impact
- Fixes UI freeze during Questionnaire rendering for affected nested skip-logic patterns.
- Backward-compatible: only tightens consistency of existing parent/child disabled semantics.