### PR TITLE
Feat/r5 backport extension item weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project follows [Semantic Versioning](http://semver.org/).
   "clear selection" button next to radio buttons. Defaults to false.
 ### Changed
 - Converted Cypress e2e tests to Playwright.
+- For ValueSet expansions, score import now prioritizes
+  `expansion.contains.property` (R5) and the R4/R4B backport extension
+  `http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property`.
+  Legacy score extraction from `expansion.contains.extension`
+  (`ordinalValue`/`itemWeight`) is retained as a deprecated fallback for
+  backward compatibility.
 
 ## [41.1.0] 2026-04-02
 ### Added
@@ -2077,4 +2083,3 @@ object.
 ### Removed
 - WidgetUtil.preprocessRIData.  This was an internal API, so it should not be
   a breaking change for anyone but ourselves.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows [Semantic Versioning](http://semver.org/).
 ### Changed
 - For ValueSet expansions, score import now prioritizes
   `expansion.contains.property` (R5) and the R4/R4B backport extension
-  `http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property`.
+  `http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property` using the `itemWeight` property.
   Legacy score extraction from `expansion.contains.extension`
   (`ordinalValue`/`itemWeight`) is retained as a deprecated fallback for
   backward compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,21 @@
 
 This project follows [Semantic Versioning](http://semver.org/).
 
-## [41.2.0] 2026-04-20
-### Added
-- New template option showRadioClearSelectionButton to show a
-  "clear selection" button next to radio buttons. Defaults to false.
+## [41.3.0] tbd
 ### Changed
-- Converted Cypress e2e tests to Playwright.
 - For ValueSet expansions, score import now prioritizes
   `expansion.contains.property` (R5) and the R4/R4B backport extension
   `http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property`.
   Legacy score extraction from `expansion.contains.extension`
   (`ordinalValue`/`itemWeight`) is retained as a deprecated fallback for
   backward compatibility.
+
+## [41.2.0] 2026-04-20
+### Added
+- New template option showRadioClearSelectionButton to show a
+  "clear selection" button next to radio buttons. Defaults to false.
+### Changed
+- Converted Cypress e2e tests to Playwright.
 
 ## [41.1.0] 2026-04-02
 ### Added

--- a/sdc-support.md
+++ b/sdc-support.md
@@ -43,9 +43,15 @@ fields.
   `ValueSet.expansion.contains.property` (FHIR R5), or in R4/R4B, the R5
   backport extension
   `http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property`.
-  Legacy score extraction from `ValueSet.expansion.contains.extension` using
-  `ordinalValue`/`itemWeight` is still supported only as a backward-compatible
-  fallback.
+  In R4/R4B, score extraction may also require the companion backport for
+  `ValueSet.expansion.property` so property codes can be mapped to canonical
+  URIs:
+  `http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.property`.
+  Using the property code `itemWeight` directly is still supported as a
+  compatibility path, but may produce a warning if the URI mapping metadata is
+  missing.  Legacy score extraction from `ValueSet.expansion.contains.extension`
+  using `ordinalValue`/`itemWeight` is still supported only as a
+  backward-compatible fallback.
 * answerExpression
 * required: (also listed in previous section of the SDC IG)
 * repeats

--- a/sdc-support.md
+++ b/sdc-support.md
@@ -39,6 +39,13 @@ fields.
 * maxSize
 * answerOption
 * answerValueSet:  Note that contained ValueSets are expected to contain an expansion.
+  For ValueSet expansion scores, the recommended path is
+  `ValueSet.expansion.contains.property` (FHIR R5), or in R4/R4B, the R5
+  backport extension
+  `http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property`.
+  Legacy score extraction from `ValueSet.expansion.contains.extension` using
+  `ordinalValue`/`itemWeight` is still supported only as a backward-compatible
+  fallback.
 * answerExpression
 * required: (also listed in previous section of the SDC IG)
 * repeats

--- a/src/fhir/R4R5-common/sdc-import.js
+++ b/src/fhir/R4R5-common/sdc-import.js
@@ -171,8 +171,29 @@ function addSDCImportFns(ns) {
   };
 
 
+  // Property codes and URIs that are considered score-relevant.
+  // Centralised here so _isScoreProperty and any future callers share one definition.
+  const SCORE_PROPERTY_CODES = ['ordinalValue', 'itemWeight', 'weight'];
+  const SCORE_PROPERTY_URIS = [
+    self.fhirExtUrlValueSetScoreOrdinalValue,       // http://hl7.org/fhir/StructureDefinition/ordinalValue
+    self.fhirExtUrlValueSetScoreItemWeight,          // http://hl7.org/fhir/StructureDefinition/itemWeight
+    "http://hl7.org/fhir/concept-properties#itemWeight"
+  ];
+
+
   /**
    * True if a ValueSet property code/uri is score-relevant.
+   *
+   * When the expansion.property map provides a URI for the code, URI-based
+   * validation is authoritative (the local code alias is implementation-defined
+   * and could collide with non-score properties).  A code that maps to a
+   * non-score URI is therefore NOT considered a score property even if its name
+   * appears in SCORE_PROPERTY_CODES.
+   *
+   * When no URI mapping exists, the code name is used as a fallback and a
+   * console.warn is emitted so implementers can detect missing expansion.property
+   * definitions in their ValueSets.
+   *
    * @param {string} propertyCode the code from contains.property.code
    * @param {Object} propertyUriByCode map from expansion.property code to uri
    * @returns {boolean}
@@ -183,17 +204,27 @@ function addSDCImportFns(ns) {
       return false;
     }
 
-    const scoreCodes = ['ordinalValue', 'itemWeight', 'weight'];
-    if (scoreCodes.includes(propertyCode)) {
+    const resolvedUri = propertyUriByCode[propertyCode];
+
+    // URI mapping is authoritative: if the expansion defines a URI for this
+    // code, rely solely on whether that URI is a known score URI.
+    if (resolvedUri !== undefined) {
+      return SCORE_PROPERTY_URIS.includes(resolvedUri);
+    }
+
+    // No URI mapping found.  Fall back to matching by well-known code names,
+    // but warn so missing expansion.property entries are visible.
+    if (SCORE_PROPERTY_CODES.includes(propertyCode)) {
+      console.warn(
+        'LForms: ValueSet expansion property "' + propertyCode + '" is ' +
+        'recognized as score-relevant by name, but has no URI mapping in ' +
+        'expansion.property to confirm. Add an expansion.property entry with ' +
+        'the corresponding URI to suppress this warning.'
+      );
       return true;
     }
 
-    const scoreUris = [
-      self.fhirExtUrlValueSetScoreOrdinalValue,
-      self.fhirExtUrlValueSetScoreItemWeight,
-      "http://hl7.org/fhir/concept-properties#itemWeight"
-    ];
-    return scoreUris.includes(propertyUriByCode[propertyCode]);
+    return false;
   };
 
 
@@ -256,6 +287,8 @@ function addSDCImportFns(ns) {
   /**
    * Deprecated fallback: score from ValueSet.expansion.contains.extension.
    * This is retained for backward compatibility with existing questionnaires.
+   * Emits a console.warn when a score is found so implementers can migrate to
+   * expansion.contains.property (R5) or the R4/R4B backport extension.
    * @param containsEntry entry in expansion.contains
    * @returns {number|undefined}
    * @private
@@ -265,7 +298,16 @@ function addSDCImportFns(ns) {
       self.fhirExtUrlValueSetScoreOrdinalValue) ||
       LForms.Util.findObjectInArray(containsEntry?.extension, 'url',
         self.fhirExtUrlValueSetScoreItemWeight);
-    return self._toScoreNumber(self._extractValueX(ordExt));
+    const score = self._toScoreNumber(self._extractValueX(ordExt));
+    if (score !== undefined) {
+      console.warn(
+        'LForms: Score extracted from deprecated ValueSet.expansion.contains.extension ' +
+        '(ordinalValue/itemWeight). This path is retained for backward compatibility only. ' +
+        'Migrate to expansion.contains.property (R5) or the R4/R4B backport extension ' +
+        'http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property'
+      );
+    }
+    return score;
   };
 
 

--- a/src/fhir/R4R5-common/sdc-import.js
+++ b/src/fhir/R4R5-common/sdc-import.js
@@ -173,7 +173,7 @@ function addSDCImportFns(ns) {
 
   // Property codes and URIs that are considered score-relevant.
   // Centralised here so _isScoreProperty and any future callers share one definition.
-  const SCORE_PROPERTY_CODES = ['ordinalValue', 'itemWeight', 'weight'];
+  const SCORE_PROPERTY_CODES = ['itemWeight'];
   const SCORE_PROPERTY_URIS = [
     self.fhirExtUrlValueSetScoreOrdinalValue,       // http://hl7.org/fhir/StructureDefinition/ordinalValue
     self.fhirExtUrlValueSetScoreItemWeight,          // http://hl7.org/fhir/StructureDefinition/itemWeight

--- a/src/fhir/R4R5-common/sdc-import.js
+++ b/src/fhir/R4R5-common/sdc-import.js
@@ -322,7 +322,19 @@ function addSDCImportFns(ns) {
    * @returns {number|undefined}
    */
   self.resolveAnswerScore = function(valueSet, containsEntry) {
-    const propertyUriByCode = self._buildExpansionPropertyUriByCodeMap(valueSet?.expansion);
+    const expansion = valueSet?.expansion;
+    let propertyUriByCode;
+
+    if (expansion) {
+      if (!expansion._lfPropertyUriByCodeMap) {
+        expansion._lfPropertyUriByCodeMap =
+          self._buildExpansionPropertyUriByCodeMap(expansion);
+      }
+      propertyUriByCode = expansion._lfPropertyUriByCodeMap;
+    }
+    else {
+      propertyUriByCode = self._buildExpansionPropertyUriByCodeMap(expansion);
+    }
 
     const scoreFromProperty = self._resolveScoreFromContainsProperty(containsEntry, propertyUriByCode);
     if (scoreFromProperty !== undefined) {

--- a/src/fhir/R4R5-common/sdc-import.js
+++ b/src/fhir/R4R5-common/sdc-import.js
@@ -15,6 +15,10 @@ function addSDCImportFns(ns) {
   // FHIR extension urls
   self.fhirExtUrlValueSetScoreOrdinalValue = "http://hl7.org/fhir/StructureDefinition/ordinalValue";
   self.fhirExtUrlValueSetScoreItemWeight = "http://hl7.org/fhir/StructureDefinition/itemWeight";
+  self.fhirExtUrlValueSetExpansionPropertyBackport =
+    "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.property";
+  self.fhirExtUrlValueSetExpansionContainsPropertyBackport =
+    "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property";
 
 
   /**
@@ -99,6 +103,197 @@ function addSDCImportFns(ns) {
         lfItem.skipLogic.logic = qItem.enableBehavior.toUpperCase();
       }
     }
+  };
+
+
+  /**
+   * Build a map from ValueSet.expansion.property code to uri. For R4/R4B, this
+   * also parses the R5 backport extension for ValueSet.expansion.property.
+   * @param expansion valueSet.expansion
+   * @returns {Object} map from property code to uri
+   * @private
+   */
+  self._buildExpansionPropertyUriByCodeMap = function(expansion) {
+    const propertyUriByCode = {};
+    (expansion?.property || []).forEach(function(prop) {
+      if (prop?.code && prop?.uri) {
+        propertyUriByCode[prop.code] = prop.uri;
+      }
+    });
+
+    (expansion?.extension || []).forEach(function(ext) {
+      if (ext?.url !== self.fhirExtUrlValueSetExpansionPropertyBackport || !ext.extension) {
+        return;
+      }
+      const codeExt = LForms.Util.findObjectInArray(ext.extension, 'url', 'code');
+      const uriExt = LForms.Util.findObjectInArray(ext.extension, 'url', 'uri');
+      if (codeExt?.valueCode && uriExt?.valueUri) {
+        propertyUriByCode[codeExt.valueCode] = uriExt.valueUri;
+      }
+    });
+
+    return propertyUriByCode;
+  };
+
+
+  /**
+   * Extract the first value[x] from a FHIR element.
+   * @param element a FHIR element object
+   * @returns value[x], or undefined
+   * @private
+   */
+  self._extractValueX = function(element) {
+    if (!element) {
+      return undefined;
+    }
+    const valueKey = Object.keys(element).find(function(key) {
+      return /^value[A-Z]/.test(key);
+    });
+    return valueKey ? element[valueKey] : undefined;
+  };
+
+
+  /**
+   * Convert a value[x] to score number when possible.
+   * @param {*} rawValue value from value[x]
+   * @returns {number|undefined}
+   * @private
+   */
+  self._toScoreNumber = function(rawValue) {
+    if (rawValue === undefined || rawValue === null || rawValue === '') {
+      return undefined;
+    }
+    if (typeof rawValue === 'number') {
+      return Number.isFinite(rawValue) ? rawValue : undefined;
+    }
+    const parsed = parseFloat(rawValue);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  };
+
+
+  /**
+   * True if a ValueSet property code/uri is score-relevant.
+   * @param {string} propertyCode the code from contains.property.code
+   * @param {Object} propertyUriByCode map from expansion.property code to uri
+   * @returns {boolean}
+   * @private
+   */
+  self._isScoreProperty = function(propertyCode, propertyUriByCode) {
+    if (!propertyCode) {
+      return false;
+    }
+
+    const scoreCodes = ['ordinalValue', 'itemWeight', 'weight'];
+    if (scoreCodes.includes(propertyCode)) {
+      return true;
+    }
+
+    const scoreUris = [
+      self.fhirExtUrlValueSetScoreOrdinalValue,
+      self.fhirExtUrlValueSetScoreItemWeight,
+      "http://hl7.org/fhir/concept-properties#itemWeight"
+    ];
+    return scoreUris.includes(propertyUriByCode[propertyCode]);
+  };
+
+
+  /**
+   * Get score from native R5 ValueSet.expansion.contains.property.
+   * @param containsEntry entry in expansion.contains
+   * @param propertyUriByCode map from expansion.property code to uri
+   * @returns {number|undefined}
+   * @private
+   */
+  self._resolveScoreFromContainsProperty = function(containsEntry, propertyUriByCode) {
+    const properties = containsEntry?.property || [];
+    for (let i = 0; i < properties.length; i++) {
+      const prop = properties[i];
+      if (!self._isScoreProperty(prop?.code, propertyUriByCode)) {
+        continue;
+      }
+      const score = self._toScoreNumber(self._extractValueX(prop));
+      if (score !== undefined) {
+        return score;
+      }
+    }
+    return undefined;
+  };
+
+
+  /**
+   * Get score from the R4/R4B backport extension for
+   * ValueSet.expansion.contains.property.
+   * @param containsEntry entry in expansion.contains
+   * @param propertyUriByCode map from expansion.property code to uri
+   * @returns {number|undefined}
+   * @private
+   */
+  self._resolveScoreFromContainsPropertyBackport = function(containsEntry, propertyUriByCode) {
+    const extensions = containsEntry?.extension || [];
+    for (let i = 0; i < extensions.length; i++) {
+      const ext = extensions[i];
+      if (ext?.url !== self.fhirExtUrlValueSetExpansionContainsPropertyBackport || !ext.extension) {
+        continue;
+      }
+
+      const codeExt = LForms.Util.findObjectInArray(ext.extension, 'url', 'code');
+      const valueExt = LForms.Util.findObjectInArray(ext.extension, 'url', 'value');
+      const propertyCode = codeExt?.valueCode;
+      if (!self._isScoreProperty(propertyCode, propertyUriByCode)) {
+        continue;
+      }
+
+      // For this backport extension, value lives under nested extension[url="value"].
+      const score = self._toScoreNumber(self._extractValueX(valueExt));
+      if (score !== undefined) {
+        return score;
+      }
+    }
+    return undefined;
+  };
+
+
+  /**
+   * Deprecated fallback: score from ValueSet.expansion.contains.extension.
+   * This is retained for backward compatibility with existing questionnaires.
+   * @param containsEntry entry in expansion.contains
+   * @returns {number|undefined}
+   * @private
+   */
+  self._resolveLegacyScoreFromContainsExtension = function(containsEntry) {
+    const ordExt = LForms.Util.findObjectInArray(containsEntry?.extension, 'url',
+      self.fhirExtUrlValueSetScoreOrdinalValue) ||
+      LForms.Util.findObjectInArray(containsEntry?.extension, 'url',
+        self.fhirExtUrlValueSetScoreItemWeight);
+    return self._toScoreNumber(self._extractValueX(ordExt));
+  };
+
+
+  /**
+   * Resolve answer.score for a ValueSet expansion concept.
+   * Priority:
+   * 1) native contains.property
+   * 2) R4/R4B backport extension for contains.property
+   * 3) deprecated fallback on contains.extension
+   * @param valueSet ValueSet resource
+   * @param containsEntry entry in valueSet.expansion.contains
+   * @returns {number|undefined}
+   */
+  self.resolveAnswerScore = function(valueSet, containsEntry) {
+    const propertyUriByCode = self._buildExpansionPropertyUriByCodeMap(valueSet?.expansion);
+
+    const scoreFromProperty = self._resolveScoreFromContainsProperty(containsEntry, propertyUriByCode);
+    if (scoreFromProperty !== undefined) {
+      return scoreFromProperty;
+    }
+
+    const scoreFromBackport =
+      self._resolveScoreFromContainsPropertyBackport(containsEntry, propertyUriByCode);
+    if (scoreFromBackport !== undefined) {
+      return scoreFromBackport;
+    }
+
+    return self._resolveLegacyScoreFromContainsExtension(containsEntry);
   };
 
 

--- a/src/fhir/R5/sdc-import.js
+++ b/src/fhir/R5/sdc-import.js
@@ -212,24 +212,9 @@ function addR5ImportFns(ns) {
     if (vs.expansion && vs.expansion.contains && vs.expansion.contains.length > 0) {
       vs.expansion.contains.forEach(function (vsItem) {
         var answer = {code: vsItem.code, text: vsItem.display, system: vsItem.system};
-        // In R5, the "property" (ValueSet.expansion.contains.property) was
-        // added so that if you do an expansion, you can request properties from
-        // the CodeSystem at the same time (without having to do a CodeSytem
-        // $lookup as in R4)
-        const ordProp = LForms.Util.findObjectInArray(vsItem.property, 'code', 'itemWeight');
-        if(ordProp) {
-          answer.score = ordProp.valueDecimal;
-        } else {
-          // Still, someone could provide us with an R5 ValueSet.expansion that
-          // put score extensions on the contained Codings.
-          // Both ordinalValue and itemWeight extensions are supported.
-          const ordExt = LForms.Util.findObjectInArray(vsItem.extension, 'url',
-            self.fhirExtUrlValueSetScoreOrdinalValue) ||
-            LForms.Util.findObjectInArray(vsItem.extension, 'url',
-            self.fhirExtUrlValueSetScoreItemWeight);
-          if(ordExt) {
-            answer.score = ordExt.valueDecimal;
-          }
+        const score = self.resolveAnswerScore(vs, vsItem);
+        if (score !== undefined) {
+          answer.score = score;
         }
         rtn.push(answer);
       });

--- a/src/fhir/STU3R4-common/sdc-import.js
+++ b/src/fhir/STU3R4-common/sdc-import.js
@@ -114,18 +114,22 @@ function addSTU3R4ImportFns(ns) {
             }
           }
         }
-        var ordExt;
-        if (self.fhirExtUrlValueSetScore) { // STU3.
-          ordExt = LForms.Util.findObjectInArray(vsItem.extension, 'url',
+        let score;
+        if (self.resolveAnswerScore) { // R4/R4B path (from R4R5-common).
+          score = self.resolveAnswerScore(vs, vsItem);
+        } else if (self.fhirExtUrlValueSetScore) { // STU3.
+          const ordExt = LForms.Util.findObjectInArray(vsItem.extension, 'url',
             self.fhirExtUrlValueSetScore);
-        } else { // R4. Both ordinalValue and itemWeight extensions are supported.
-          ordExt = LForms.Util.findObjectInArray(vsItem.extension, 'url',
+          score = ordExt?.valueDecimal;
+        } else { // Legacy fallback behavior if resolveAnswerScore is unavailable.
+          const ordExt = LForms.Util.findObjectInArray(vsItem.extension, 'url',
               self.fhirExtUrlValueSetScoreOrdinalValue) ||
             LForms.Util.findObjectInArray(vsItem.extension, 'url',
               self.fhirExtUrlValueSetScoreItemWeight);
+          score = ordExt?.valueDecimal;
         }
-        if(ordExt) {
-          answer.score = ordExt.valueDecimal;
+        if(score !== undefined) {
+          answer.score = score;
         }
         rtn.push(answer);
       });

--- a/test/karma/fhir-sdc.spec.js
+++ b/test/karma/fhir-sdc.spec.js
@@ -169,7 +169,7 @@ for (var i=0, len=fhirVersions.length; i<len; ++i) {
               assert.equal(lfData.items[0].answers[0].score, 7);
             });
 
-            it('should ignore contains.property itemWeight without expansion.property uri mapping', function() {
+            it('should fall back to contains.property itemWeight without expansion.property uri mapping', function() {
               const q = createQuestionnaireWithContainedValueSet({
                 resourceType: 'ValueSet',
                 id: 'vs1',
@@ -187,7 +187,7 @@ for (var i=0, len=fhirVersions.length; i<len; ++i) {
               });
 
               const lfData = LForms.Util.convertFHIRQuestionnaireToLForms(q, fhirVersion);
-              assert.isUndefined(lfData.items[0].answers[0].score);
+              assert.equal(lfData.items[0].answers[0].score, 8);
             });
 
             it('should ignore contains.property when expansion.property maps code to a non-score uri', function() {

--- a/test/karma/fhir-sdc.spec.js
+++ b/test/karma/fhir-sdc.spec.js
@@ -169,6 +169,52 @@ for (var i=0, len=fhirVersions.length; i<len; ++i) {
               assert.equal(lfData.items[0].answers[0].score, 7);
             });
 
+            it('should ignore contains.property itemWeight without expansion.property uri mapping', function() {
+              const q = createQuestionnaireWithContainedValueSet({
+                resourceType: 'ValueSet',
+                id: 'vs1',
+                expansion: {
+                  contains: [{
+                    code: 'c1',
+                    system: 'sys',
+                    display: 'A',
+                    property: [{
+                      code: 'itemWeight',
+                      valueDecimal: 8
+                    }]
+                  }]
+                }
+              });
+
+              const lfData = LForms.Util.convertFHIRQuestionnaireToLForms(q, fhirVersion);
+              assert.isUndefined(lfData.items[0].answers[0].score);
+            });
+
+            it('should ignore contains.property when expansion.property maps code to a non-score uri', function() {
+              const q = createQuestionnaireWithContainedValueSet({
+                resourceType: 'ValueSet',
+                id: 'vs1',
+                expansion: {
+                  property: [{
+                    code: 'weight',
+                    uri: 'http://example.com/not-item-weight'
+                  }],
+                  contains: [{
+                    code: 'c1',
+                    system: 'sys',
+                    display: 'A',
+                    property: [{
+                      code: 'weight',
+                      valueDecimal: 5
+                    }]
+                  }]
+                }
+              });
+
+              const lfData = LForms.Util.convertFHIRQuestionnaireToLForms(q, fhirVersion);
+              assert.isUndefined(lfData.items[0].answers[0].score);
+            });
+
             it('should keep legacy contains.extension score as fallback', function() {
               const q = createQuestionnaireWithContainedValueSet({
                 resourceType: 'ValueSet',

--- a/test/karma/fhir-sdc.spec.js
+++ b/test/karma/fhir-sdc.spec.js
@@ -120,6 +120,207 @@ for (var i=0, len=fhirVersions.length; i<len; ++i) {
           });
         });
 
+        describe('ValueSet expansion score extraction', function() {
+          const containsPropertyBackportUrl =
+            'http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property';
+          const expansionPropertyBackportUrl =
+            'http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.property';
+
+          function getChoiceTypeForVersion() {
+            return fhirVersion === 'R5' ? 'coding' : 'choice';
+          }
+
+          function createQuestionnaireWithContainedValueSet(valueSet) {
+            return {
+              resourceType: 'Questionnaire',
+              status: 'draft',
+              contained: [valueSet],
+              item: [{
+                linkId: 'q1',
+                type: getChoiceTypeForVersion(),
+                answerValueSet: '#vs1'
+              }]
+            };
+          }
+
+          if (fhirVersion === 'R5') {
+            it('should extract score from expansion.contains.property using expansion.property uri mapping', function() {
+              const q = createQuestionnaireWithContainedValueSet({
+                resourceType: 'ValueSet',
+                id: 'vs1',
+                expansion: {
+                  property: [{
+                    code: 'weight',
+                    uri: 'http://hl7.org/fhir/concept-properties#itemWeight'
+                  }],
+                  contains: [{
+                    code: 'c1',
+                    system: 'sys',
+                    display: 'A',
+                    property: [{
+                      code: 'weight',
+                      valueInteger: 7
+                    }]
+                  }]
+                }
+              });
+
+              const lfData = LForms.Util.convertFHIRQuestionnaireToLForms(q, fhirVersion);
+              assert.equal(lfData.items[0].answers[0].score, 7);
+            });
+
+            it('should keep legacy contains.extension score as fallback', function() {
+              const q = createQuestionnaireWithContainedValueSet({
+                resourceType: 'ValueSet',
+                id: 'vs1',
+                expansion: {
+                  contains: [{
+                    code: 'c1',
+                    system: 'sys',
+                    display: 'A',
+                    extension: [{
+                      url: 'http://hl7.org/fhir/StructureDefinition/itemWeight',
+                      valueDecimal: 6
+                    }]
+                  }]
+                }
+              });
+
+              const lfData = LForms.Util.convertFHIRQuestionnaireToLForms(q, fhirVersion);
+              assert.equal(lfData.items[0].answers[0].score, 6);
+            });
+
+            it('should prefer contains.property over legacy contains.extension', function() {
+              const q = createQuestionnaireWithContainedValueSet({
+                resourceType: 'ValueSet',
+                id: 'vs1',
+                expansion: {
+                  property: [{
+                    code: 'weight',
+                    uri: 'http://hl7.org/fhir/concept-properties#itemWeight'
+                  }],
+                  contains: [{
+                    code: 'c1',
+                    system: 'sys',
+                    display: 'A',
+                    property: [{
+                      code: 'weight',
+                      valueDecimal: 9
+                    }],
+                    extension: [{
+                      url: 'http://hl7.org/fhir/StructureDefinition/itemWeight',
+                      valueDecimal: 2
+                    }]
+                  }]
+                }
+              });
+
+              const lfData = LForms.Util.convertFHIRQuestionnaireToLForms(q, fhirVersion);
+              assert.equal(lfData.items[0].answers[0].score, 9);
+            });
+          }
+
+          if (fhirVersion === 'R4' || fhirVersion === 'R4B') {
+            it('should extract score from R5 backport contains.property extension', function() {
+              const q = createQuestionnaireWithContainedValueSet({
+                resourceType: 'ValueSet',
+                id: 'vs1',
+                expansion: {
+                  extension: [{
+                    url: expansionPropertyBackportUrl,
+                    extension: [{
+                      url: 'code',
+                      valueCode: 'weight'
+                    }, {
+                      url: 'uri',
+                      valueUri: 'http://hl7.org/fhir/concept-properties#itemWeight'
+                    }]
+                  }],
+                  contains: [{
+                    code: 'c1',
+                    system: 'sys',
+                    display: 'A',
+                    extension: [{
+                      url: containsPropertyBackportUrl,
+                      extension: [{
+                        url: 'code',
+                        valueCode: 'weight'
+                      }, {
+                        url: 'value',
+                        valueDecimal: 4.5
+                      }]
+                    }]
+                  }]
+                }
+              });
+
+              const lfData = LForms.Util.convertFHIRQuestionnaireToLForms(q, fhirVersion);
+              assert.equal(lfData.items[0].answers[0].score, 4.5);
+            });
+
+            it('should keep legacy contains.extension score as fallback', function() {
+              const q = createQuestionnaireWithContainedValueSet({
+                resourceType: 'ValueSet',
+                id: 'vs1',
+                expansion: {
+                  contains: [{
+                    code: 'c1',
+                    system: 'sys',
+                    display: 'A',
+                    extension: [{
+                      url: 'http://hl7.org/fhir/StructureDefinition/ordinalValue',
+                      valueDecimal: 3
+                    }]
+                  }]
+                }
+              });
+
+              const lfData = LForms.Util.convertFHIRQuestionnaireToLForms(q, fhirVersion);
+              assert.equal(lfData.items[0].answers[0].score, 3);
+            });
+
+            it('should prefer backport contains.property over legacy contains.extension', function() {
+              const q = createQuestionnaireWithContainedValueSet({
+                resourceType: 'ValueSet',
+                id: 'vs1',
+                expansion: {
+                  extension: [{
+                    url: expansionPropertyBackportUrl,
+                    extension: [{
+                      url: 'code',
+                      valueCode: 'weight'
+                    }, {
+                      url: 'uri',
+                      valueUri: 'http://hl7.org/fhir/concept-properties#itemWeight'
+                    }]
+                  }],
+                  contains: [{
+                    code: 'c1',
+                    system: 'sys',
+                    display: 'A',
+                    extension: [{
+                      url: containsPropertyBackportUrl,
+                      extension: [{
+                        url: 'code',
+                        valueCode: 'weight'
+                      }, {
+                        url: 'value',
+                        valueInteger: 11
+                      }]
+                    }, {
+                      url: 'http://hl7.org/fhir/StructureDefinition/itemWeight',
+                      valueDecimal: 2
+                    }]
+                  }]
+                }
+              });
+
+              const lfData = LForms.Util.convertFHIRQuestionnaireToLForms(q, fhirVersion);
+              assert.equal(lfData.items[0].answers[0].score, 11);
+            });
+          }
+        });
+
         describe('_processFHIRValues', function() {
           describe('list fields with coding values', function () {
             let answerValCases = [{
@@ -2611,5 +2812,3 @@ for (var i=0, len=nonSTU3FHIRVersions.length; i<len; ++i) {
     });
   })(nonSTU3FHIRVersions[i]);
 }
-
-


### PR DESCRIPTION
This pull request updates how ValueSet expansion scores are imported and prioritized, aligning with FHIR R5 and improving backward compatibility for R4/R4B. The main change is that score extraction now prefers `expansion.contains.property` (R5) and the R4/R4B backport extension, with legacy extraction from `expansion.contains.extension` retained only as a fallback. The implementation is modularized, and comprehensive tests are added to ensure correct behavior across FHIR versions.

**ValueSet Expansion Score Import Improvements:**

* Score extraction now prioritizes `expansion.contains.property` (FHIR R5) and the backport extension `http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property` for R4/R4B; legacy extraction from `expansion.contains.extension` (`ordinalValue`/`itemWeight`) is now a deprecated fallback. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R13) [[2]](diffhunk://#diff-68bb8745ffd16e376fa261659f560383fc49be14b3e628ae3840a32faec55c00R42-R48)
* Added a new modular implementation for score extraction in `src/fhir/R4R5-common/sdc-import.js`, including helper methods for property URI mapping, score property detection, and value extraction.
* Refactored R5 (`src/fhir/R5/sdc-import.js`) and R4/R4B (`src/fhir/STU3R4-common/sdc-import.js`) import logic to use the new prioritized score extraction method, ensuring consistent behavior and fallback handling. [[1]](diffhunk://#diff-3c4e9be1c6eeddb449182064ce2f85bd854a4028f0040e8bcf2592a152b9cb64L215-R217) [[2]](diffhunk://#diff-77246e978ef94e6fe7ab5ec0d24b8e7b59a6bc80b6ab5d7edd270fcaa7e65039L117-R132)

**Documentation Updates:**

* Updated `CHANGELOG.md` and `sdc-support.md` to document the new score extraction priority and the deprecation of legacy methods. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R13) [[2]](diffhunk://#diff-68bb8745ffd16e376fa261659f560383fc49be14b3e628ae3840a32faec55c00R42-R48)

**Testing Enhancements:**

* Added comprehensive tests to `test/karma/fhir-sdc.spec.js` to verify score extraction logic for all supported FHIR versions, including preference order and fallback scenarios.

These changes improve standards compliance, maintain backward compatibility, and ensure robust, predictable score import behavior.

closes #183