### PR TITLE
Refactor build:version script to make it OS independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ you don't accidentally add something that we are also working on.
 - Run `npm run build` to build the project and generate a production version of
   the js files, which are much smaller than the development version. It
   generates an ES2017 version of the js files under dist/lforms. For details on
-  the files to load, see ["Usng the LHC-Forms Web Component"](#using).  
+  the files to load, see ["Using the LHC-Forms Web Component"](#using).  
   The `dist` directory is deleted and recreated during the process.
 
   The build also concatenates all the js files (except for zone.min.js and the

--- a/bin/build-version.js
+++ b/bin/build-version.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+const packageJson = require('../package.json');
+
+fs.writeFileSync('src/version.json', JSON.stringify({
+  lformsVersion: packageJson.version
+}));
+

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:init": "npm run build:clean && shx mkdir -p dist/$npm_package_name && shx cp src/index.js dist && npm run build:version && npm run build:language",
     "build:prepare-zip": "node prepare-zip.js",
     "build:zip": "cd dist;  shx mv $npm_package_name $npm_package_name-$npm_package_version; bestzip $npm_package_name-$npm_package_version.zip $npm_package_name-$npm_package_version/*; shx mv $npm_package_name-$npm_package_version $npm_package_name",
-    "build:version": "node -e 'require(\"fs\").writeFileSync(\"src/version.json\", JSON.stringify({lformsVersion: require(\"./package.json\").version}))'",
+    "build:version": "node bin/build-version.js",
     "build:language": "node bin/build-locale.js $npm_package_config_localeID",
     "test:fhir-unit": "karma start test/karma.conf.js",
     "test:ng-unit": "ng test --watch=false",


### PR DESCRIPTION
The current `build:version` script does not run on Windows and this problem is not documented in the Readme (or I did not find it). Externailzing the script into a separate file should make it work on all systems.

Important:
- This refactoring stems from AI (Copilot Claude Agent)
- I have only tested it on Windows 